### PR TITLE
fix buffer overrun of initvmix's ww2 vector

### DIFF
--- a/src/qpGraph.c
+++ b/src/qpGraph.c
@@ -2094,6 +2094,8 @@ initvmix (double *wwinit, int nwts, int numiter)
   nedge = getnumedge ();
   nanc =  getnumanc() ;
   nvar = nedge + nanc*(nanc-1)/2 ;
+  if (nvar < nwts)
+    nvar = nwts;
   ng2 = numeg * numeg;
 
   ZALLOC (ff3fit, ng2, double);


### PR DESCRIPTION
Ensures that the ww2 vector is allocated to be at least as large as the ww vector with which it is multiplied by ensuring that `nvar` is at least as large as `nwts`. 

Not sure if this is "correct" in terms of the algorithm but it does fix the crash which results from the buffer overrun caused by `nvar` being smaller than `nwts`, and qpGraph runs to completion after applying this fix. 

Fixes #17 