### PR TITLE
fix typo in Makefile(s)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -119,7 +119,7 @@ install:	all dirs tables
 	cp $(PROGS) $(TOP)
 	cp $(PROGS2) $(TOP)
 	cp $(PROGS3) $(TOP)
-	cp $(PROGS3) $(TOP)
+	cp $(PROGS4) $(TOP)
 	cp ../perlsrc/* $(TOP) 
 	cp fxtract $(BIN)
 	cp -r script $(BIN) 

--- a/src/Makefile.mac
+++ b/src/Makefile.mac
@@ -128,7 +128,7 @@ install:	all dirs tables
 	cp $(PROGS) $(TOP)
 	cp $(PROGS2) $(TOP)
 	cp $(PROGS3) $(TOP)
-	cp $(PROGS3) $(TOP)
+	cp $(PROGS4) $(TOP)
 	cp ../perlsrc/* $(TOP) 
 	cp ../pysrc/* $(TOP) 
 	cp fxtract $(BIN)


### PR DESCRIPTION
copy over `$(PROGS4)` to `bin` instead of doing `$(PROGS3)` twice.

cc @MatthewMah @bumblenick 