### PR TITLE
fix: declaration inconsist

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -119,7 +119,7 @@ install:	all dirs tables
 	cp $(PROGS) $(TOP)
 	cp $(PROGS2) $(TOP)
 	cp $(PROGS3) $(TOP)
-	cp $(PROGS3) $(TOP)
+	cp $(PROGS4) $(TOP)
 	cp ../perlsrc/* $(TOP) 
 	cp fxtract $(BIN)
 	cp -r script $(BIN) 

--- a/src/qpgsubs.c
+++ b/src/qpgsubs.c
@@ -125,7 +125,7 @@ void setdisq(NODE *node, int dis)  ;
 void setdisqq(NODE *node, int dis)  ;
 int setxx (NODE * node, NODE ** xx);
 void reroot (char *nodename);
-void setgtime ();
+void setgtime (double *time);
 void setvnum (int *vnum, int *list, int n);
 void pedge (FILE * fff, NODE * anode, NODE * bnode, double val, double theta, int mode);
 int vertexnum (char *vertname);


### PR DESCRIPTION
qpgsubs.c:128:6: error: conflicting types for ‘setgtime’; have ‘void(void)’
  128 | void setgtime ();
      |      ^~~~~~~~